### PR TITLE
DEVEXP-564 Using CMA to retrieve forest details

### DIFF
--- a/src/main/java/com/marklogic/mgmt/resource/forests/ForestManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/forests/ForestManager.java
@@ -16,10 +16,19 @@
 package com.marklogic.mgmt.resource.forests;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.marklogic.mgmt.resource.AbstractResourceManager;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.api.API;
+import com.marklogic.mgmt.api.forest.Forest;
+import com.marklogic.mgmt.mapper.DefaultResourceMapper;
+import com.marklogic.mgmt.mapper.ResourceMapper;
+import com.marklogic.mgmt.resource.AbstractResourceManager;
 import com.marklogic.rest.util.Fragment;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -27,79 +36,116 @@ import java.util.Map;
 
 /**
  * Provides methods wrapping /manage/v2/forests endpoints.
- *
+ * <p>
  * The "save" method inherited from the parent class does not allow updates, as updates can fail for a variety of
  * reasons with forests - e.g. if the host is different. If you need to update a forest, consider just using
  * ManageClient to do it.
  */
 public class ForestManager extends AbstractResourceManager {
 
-    // Parameter values for the "level" parameter when deleting a forest
-    public final static String DELETE_LEVEL_FULL = "full";
-    public final static String DELETE_LEVEL_CONFIG_ONLY = "config-only";
+	// Parameter values for the "level" parameter when deleting a forest
+	public final static String DELETE_LEVEL_FULL = "full";
+	public final static String DELETE_LEVEL_CONFIG_ONLY = "config-only";
 
-    // Parameter values for the "replicas" parameter when deleting a forest
-    public final static String REPLICAS_DETACH = "detach";
-    public final static String REPLICAS_DELETE = "delete";
+	// Parameter values for the "replicas" parameter when deleting a forest
+	public final static String REPLICAS_DETACH = "detach";
+	public final static String REPLICAS_DELETE = "delete";
 
-    private String deleteLevel = DELETE_LEVEL_FULL;
-    private int deleteRetryAttempts = 3;
-    private long deleteSleepPeriod = 500;
+	private String deleteLevel = DELETE_LEVEL_FULL;
+	private int deleteRetryAttempts = 3;
+	private long deleteSleepPeriod = 500;
 
-    public ForestManager(ManageClient client) {
-        super(client);
+	public ForestManager(ManageClient client) {
+		super(client);
 		setUpdateAllowed(false);
-    }
+	}
 
-    public void createJsonForestWithName(String name, String host) {
-        if (forestExists(name)) {
-            logger.info(format("Forest already exists with name, so not creating: %s", name));
-        } else {
-            logger.info(format("Creating forest %s on host %s", name, host));
-            createJsonForest(format("{\"forest-name\":\"%s\", \"host\":\"%s\"}", name, host));
-            logger.info(format("Created forest %s on host %s", name, host));
-        }
-    }
+	/**
+	 * Uses CMA to get back all forests in the cluster. Then returns a map where keys are the given database names,
+	 * and each key has a list of primary forests for that database.
+	 *
+	 * @param databaseNames
+	 * @return
+	 * @since 4.5.3
+	 */
+	public Map<String, List<Forest>> getPrimaryForestsForDatabases(String... databaseNames) {
+		String uri = UriComponentsBuilder.fromUri(getManageClient().buildUri("/manage/v3"))
+			.queryParam("format", "json").queryParam("resource-type", "forest")
+			.encode().toUriString();
 
-    public void delete(String nameOrId, String level) {
-        delete(nameOrId, level, REPLICAS_DELETE);
-    }
+		JsonNode json = getManageClient().getRestTemplate().exchange(uri, HttpMethod.GET, null, JsonNode.class).getBody();
+		// Config is an array of objects, and it should have a single object based on our request.
+		ArrayNode allPrimaryForests = (ArrayNode) json.get("config").get(0).get("forest");
+		ResourceMapper mapper = new DefaultResourceMapper(new API(getManageClient()));
 
-    /**
-     * @param nameOrId Name or ID of forest to delete
-     * @param level either "full" or "config-only"
-     * @param replicas either "detach" or "delete"
-     */
-    public void delete(String nameOrId, String level, String replicas) {
-        if (!forestExists(nameOrId)) {
-            logger.info(format("Could not find forest with name or ID: %s, so not deleting", nameOrId));
-        } else {
-            logger.info(format("Deleting forest %s", nameOrId));
-            String path = format("/manage/v2/forests/%s?level=%s&replicas=%s", nameOrId, level, replicas);
-            deleteWithRetry(path, deleteRetryAttempts);
-            logger.info(format("Deleted forest %s", nameOrId));
-        }
-    }
+		List<String> dbNames = Arrays.asList(databaseNames);
+		Map<String, List<Forest>> forestMap = new HashMap<>();
+		allPrimaryForests.iterator().forEachRemaining(forest -> {
+			if (forest.has("database")) {
+				String db = forest.get("database").asText();
+				if (dbNames.contains(db)) {
+					List<Forest> forests = forestMap.get(db);
+					if (forests == null) {
+						forests = new ArrayList<>();
+						forestMap.put(db, forests);
+					}
+					forests.add(mapper.readResource(forest.toString(), Forest.class));
+				}
+			}
+		});
+		
+		return forestMap;
+	}
 
-    public void deleteWithRetry(String path, int attemptsLeft) {
-	    try {
-		    getManageClient().delete(path);
-	    } catch (Exception e) {
-	    	// Error will be logged automatically by MgmtResponseErrorHandler
-		    if (attemptsLeft > 0) {
-		    	try {
-		    		logger.warn("Unable to delete forest; will wait " + deleteSleepPeriod + "ms, then retry at path: " + path);
-				    Thread.sleep(deleteSleepPeriod);
-				    attemptsLeft--;
-				    deleteWithRetry(path, attemptsLeft);
-			    } catch (InterruptedException ex) {
-		    		// Ignore
-			    }
-		    } else {
-		    	throw e;
-		    }
-	    }
-    }
+	public void createJsonForestWithName(String name, String host) {
+		if (forestExists(name)) {
+			logger.info(format("Forest already exists with name, so not creating: %s", name));
+		} else {
+			logger.info(format("Creating forest %s on host %s", name, host));
+			createJsonForest(format("{\"forest-name\":\"%s\", \"host\":\"%s\"}", name, host));
+			logger.info(format("Created forest %s on host %s", name, host));
+		}
+	}
+
+	public void delete(String nameOrId, String level) {
+		delete(nameOrId, level, REPLICAS_DELETE);
+	}
+
+	/**
+	 * @param nameOrId Name or ID of forest to delete
+	 * @param level    either "full" or "config-only"
+	 * @param replicas either "detach" or "delete"
+	 */
+	public void delete(String nameOrId, String level, String replicas) {
+		if (!forestExists(nameOrId)) {
+			logger.info(format("Could not find forest with name or ID: %s, so not deleting", nameOrId));
+		} else {
+			logger.info(format("Deleting forest %s", nameOrId));
+			String path = format("/manage/v2/forests/%s?level=%s&replicas=%s", nameOrId, level, replicas);
+			deleteWithRetry(path, deleteRetryAttempts);
+			logger.info(format("Deleted forest %s", nameOrId));
+		}
+	}
+
+	public void deleteWithRetry(String path, int attemptsLeft) {
+		try {
+			getManageClient().delete(path);
+		} catch (Exception e) {
+			// Error will be logged automatically by MgmtResponseErrorHandler
+			if (attemptsLeft > 0) {
+				try {
+					logger.warn("Unable to delete forest; will wait " + deleteSleepPeriod + "ms, then retry at path: " + path);
+					Thread.sleep(deleteSleepPeriod);
+					attemptsLeft--;
+					deleteWithRetry(path, attemptsLeft);
+				} catch (InterruptedException ex) {
+					// Ignore
+				}
+			} else {
+				throw e;
+			}
+		}
+	}
 
 	/**
 	 * Supports either an array of JSON objects or a single JSON object.
@@ -118,125 +164,124 @@ public class ForestManager extends AbstractResourceManager {
 		}
 	}
 
-    public void createJsonForest(String json) {
-        getManageClient().postJson("/manage/v2/forests", json);
-    }
+	public void createJsonForest(String json) {
+		getManageClient().postJson("/manage/v2/forests", json);
+	}
 
-    public boolean forestExists(String nameOrId) {
-        Fragment f = getManageClient().getXml("/manage/v2/forests");
-        return f.elementExists(format("/node()/f:list-items/f:list-item[f:nameref = '%s' or f:idref = '%s']", nameOrId,
-                nameOrId));
-    }
+	public boolean forestExists(String nameOrId) {
+		Fragment f = getManageClient().getXml("/manage/v2/forests");
+		return f.elementExists(format("/node()/f:list-items/f:list-item[f:nameref = '%s' or f:idref = '%s']", nameOrId,
+			nameOrId));
+	}
 
-    public void attachForest(String forestIdOrName, String databaseIdOrName) {
-        if (isForestAttached(forestIdOrName)) {
-            logger.info(format("Forest %s is already attached to a database, not attaching", forestIdOrName));
-            return;
-        }
-        logger.info(format("Attaching forest %s to database %s", forestIdOrName, databaseIdOrName));
-        String path = format("/manage/v2/forests/%s", forestIdOrName);
-        getManageClient().postForm(path, "state", "attach", "database", databaseIdOrName);
-        logger.info(format("Attached forest %s to database %s", forestIdOrName, databaseIdOrName));
-    }
+	public void attachForest(String forestIdOrName, String databaseIdOrName) {
+		if (isForestAttached(forestIdOrName)) {
+			logger.info(format("Forest %s is already attached to a database, not attaching", forestIdOrName));
+			return;
+		}
+		logger.info(format("Attaching forest %s to database %s", forestIdOrName, databaseIdOrName));
+		String path = format("/manage/v2/forests/%s", forestIdOrName);
+		getManageClient().postForm(path, "state", "attach", "database", databaseIdOrName);
+		logger.info(format("Attached forest %s to database %s", forestIdOrName, databaseIdOrName));
+	}
 
-    public boolean isForestAttached(String forestIdOrName) {
-        Fragment f = getManageClient().getXml(format("/manage/v2/forests/%s", forestIdOrName));
-        return f.elementExists("/node()/f:relations/f:relation-group[f:typeref = 'databases']");
-    }
+	public boolean isForestAttached(String forestIdOrName) {
+		Fragment f = getManageClient().getXml(format("/manage/v2/forests/%s", forestIdOrName));
+		return f.elementExists("/node()/f:relations/f:relation-group[f:typeref = 'databases']");
+	}
 
-    public String getHostId(String forestIdOrName) {
-        Fragment f = getManageClient().getXml(format("/manage/v2/forests/%s", forestIdOrName));
-        return f.getElementValue("/node()/f:relations/f:relation-group[f:typeref = 'hosts']/f:relation/f:idref");
-    }
+	public String getHostId(String forestIdOrName) {
+		Fragment f = getManageClient().getXml(format("/manage/v2/forests/%s", forestIdOrName));
+		return f.getElementValue("/node()/f:relations/f:relation-group[f:typeref = 'hosts']/f:relation/f:idref");
+	}
 
-    /**
-     * @param forestIdOrName
-     * @param replicaNamesAndHostIds
-     *            A map where each key is a replica forest name, and its value is the host ID of that forest
-     */
-    public void setReplicas(String forestIdOrName, Map<String, String> replicaNamesAndHostIds) {
-        StringBuilder json = new StringBuilder("{\"forest-replica\":[");
-        boolean firstOne = true;
-        for (String replicaName : replicaNamesAndHostIds.keySet()) {
-            if (!firstOne) {
-                json.append(",");
-            }
-            String hostId = replicaNamesAndHostIds.get(replicaName);
-            json.append(format("{\"replica-name\":\"%s\", \"host\":\"%s\"}", replicaName, hostId));
-            firstOne = false;
-        }
-        json.append("]}");
-        if (logger.isInfoEnabled()) {
-            logger.info(format("Setting replicas for forest %s, JSON: %s", forestIdOrName, json.toString()));
-        }
-        getManageClient().putJson(getPropertiesPath(forestIdOrName), json.toString());
-        if (logger.isInfoEnabled()) {
-            logger.info(format("Finished setting replicas for forest %s", forestIdOrName));
-        }
-    }
+	/**
+	 * @param forestIdOrName
+	 * @param replicaNamesAndHostIds A map where each key is a replica forest name, and its value is the host ID of that forest
+	 */
+	public void setReplicas(String forestIdOrName, Map<String, String> replicaNamesAndHostIds) {
+		StringBuilder json = new StringBuilder("{\"forest-replica\":[");
+		boolean firstOne = true;
+		for (String replicaName : replicaNamesAndHostIds.keySet()) {
+			if (!firstOne) {
+				json.append(",");
+			}
+			String hostId = replicaNamesAndHostIds.get(replicaName);
+			json.append(format("{\"replica-name\":\"%s\", \"host\":\"%s\"}", replicaName, hostId));
+			firstOne = false;
+		}
+		json.append("]}");
+		if (logger.isInfoEnabled()) {
+			logger.info(format("Setting replicas for forest %s, JSON: %s", forestIdOrName, json.toString()));
+		}
+		getManageClient().putJson(getPropertiesPath(forestIdOrName), json.toString());
+		if (logger.isInfoEnabled()) {
+			logger.info(format("Finished setting replicas for forest %s", forestIdOrName));
+		}
+	}
 
-    /**
-     * Convenience method for detaching a forest from any replicas it has; this is often used before deleting those
-     * replicas
-     *
-     * @param forestIdOrName
-     */
-    public void setReplicasToNone(String forestIdOrName) {
-        setReplicas(forestIdOrName, new HashMap<>());
-    }
+	/**
+	 * Convenience method for detaching a forest from any replicas it has; this is often used before deleting those
+	 * replicas
+	 *
+	 * @param forestIdOrName
+	 */
+	public void setReplicasToNone(String forestIdOrName) {
+		setReplicas(forestIdOrName, new HashMap<>());
+	}
 
-    /**
-     * Returns a list of IDs for each replica forest for the given forest ID or name.
-     *
-     * @param forestIdOrName
-     * @return
-     */
-    public List<String> getReplicaIds(String forestIdOrName) {
-        String path = getResourcePath(forestIdOrName, "view", "config", "format", "xml");
-        return getManageClient().getXml(path).getElementValues(
-                "/f:forest-config/f:config-properties/f:forest-replicas/f:forest-replica");
-    }
+	/**
+	 * Returns a list of IDs for each replica forest for the given forest ID or name.
+	 *
+	 * @param forestIdOrName
+	 * @return
+	 */
+	public List<String> getReplicaIds(String forestIdOrName) {
+		String path = getResourcePath(forestIdOrName, "view", "config", "format", "xml");
+		return getManageClient().getXml(path).getElementValues(
+			"/f:forest-config/f:config-properties/f:forest-replicas/f:forest-replica");
+	}
 
-    /**
-     * Deletes (with a level of "full") all replicas for the given forest.
-     *
-     * @param forestIdOrName
-     */
-    public void deleteReplicas(String forestIdOrName) {
-        List<String> replicaIds = getReplicaIds(forestIdOrName);
-        if (replicaIds.isEmpty()) {
-            logger.info(format("Forest '%s' has no replicas, so not deleting anything", forestIdOrName));
-            return;
-        }
-        setReplicasToNone(forestIdOrName);
-        for (String id : replicaIds) {
-            delete(id, DELETE_LEVEL_FULL);
-        }
-    }
+	/**
+	 * Deletes (with a level of "full") all replicas for the given forest.
+	 *
+	 * @param forestIdOrName
+	 */
+	public void deleteReplicas(String forestIdOrName) {
+		List<String> replicaIds = getReplicaIds(forestIdOrName);
+		if (replicaIds.isEmpty()) {
+			logger.info(format("Forest '%s' has no replicas, so not deleting anything", forestIdOrName));
+			return;
+		}
+		setReplicasToNone(forestIdOrName);
+		for (String id : replicaIds) {
+			delete(id, DELETE_LEVEL_FULL);
+		}
+	}
 
-    public ForestStatus getForestStatus(String forestIdOrName) {
-        String path = getResourcePath(forestIdOrName, "view", "status", "format", "xml");
-        return new ForestStatus(getManageClient().getXml(path));
-    }
+	public ForestStatus getForestStatus(String forestIdOrName) {
+		String path = getResourcePath(forestIdOrName, "view", "status", "format", "xml");
+		return new ForestStatus(getManageClient().getXml(path));
+	}
 
-    public void setUpdatesAllowed(String forestIdOrName, String mode) {
-        String path = getPropertiesPath(forestIdOrName);
-        String json = format("{\"updates-allowed\":\"%s\"}", mode);
-        getManageClient().putJson(path, json);
-    }
+	public void setUpdatesAllowed(String forestIdOrName, String mode) {
+		String path = getPropertiesPath(forestIdOrName);
+		String json = format("{\"updates-allowed\":\"%s\"}", mode);
+		getManageClient().putJson(path, json);
+	}
 
-    @Override
-    protected String[] getDeleteResourceParams(String payload) {
-        return this.deleteLevel != null ? new String[] { "level", deleteLevel } : null;
-    }
+	@Override
+	protected String[] getDeleteResourceParams(String payload) {
+		return this.deleteLevel != null ? new String[]{"level", deleteLevel} : null;
+	}
 
-    public String getDeleteLevel() {
-        return deleteLevel;
-    }
+	public String getDeleteLevel() {
+		return deleteLevel;
+	}
 
-    public void setDeleteLevel(String deleteLevel) {
-        this.deleteLevel = deleteLevel;
-    }
+	public void setDeleteLevel(String deleteLevel) {
+		this.deleteLevel = deleteLevel;
+	}
 
 	public void setDeleteRetryAttempts(int deleteRetryAttempts) {
 		this.deleteRetryAttempts = deleteRetryAttempts;

--- a/src/test/java/com/marklogic/mgmt/resource/forests/GetPrimaryForestsTest.java
+++ b/src/test/java/com/marklogic/mgmt/resource/forests/GetPrimaryForestsTest.java
@@ -1,0 +1,33 @@
+package com.marklogic.mgmt.resource.forests;
+
+import com.marklogic.mgmt.AbstractMgmtTest;
+import com.marklogic.mgmt.api.forest.Forest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GetPrimaryForestsTest extends AbstractMgmtTest {
+
+	/**
+	 * Simple test for verifying this method works for a couple OOTB databases. It is expected that the app-deployer
+	 * tests will stress this method given that CMA is used by a default, and thus this method will be used anytime
+	 * a database is being deployed.
+	 */
+	@Test
+	void test() {
+		Map<String, List<Forest>> forestMap = new ForestManager(manageClient)
+			.getPrimaryForestsForDatabases("App-Services", "Documents");
+
+		Set<String> dbNames = forestMap.keySet();
+		assertTrue(dbNames.contains("App-Services"));
+		assertTrue(dbNames.contains("Documents"));
+		assertEquals(2, dbNames.size());
+		assertTrue(forestMap.get("App-Services").size() > 0);
+		assertTrue(forestMap.get("Documents").size() > 0);
+	}
+}


### PR DESCRIPTION
Allows for deploying databases much more quickly by getting all forest details in a single request as opposed to one request per forest via /manage/v2. Any issue results in /manage/v2 being used instead. 

A simple test was added for this, but the method is being tested by dozens of existing tests - i.e. any test that involves deploying a database is hitting this. There's no actual change in functionality too - it's purely a performance optimization. 