### PR TITLE
DEVEXP-565 Using map of forests to determining if forests have replicas

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/CommandContext.java
+++ b/src/main/java/com/marklogic/appdeployer/command/CommandContext.java
@@ -20,8 +20,13 @@ import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.admin.AdminManager;
 import com.marklogic.mgmt.api.configuration.Configuration;
 import com.marklogic.mgmt.api.configuration.Configurations;
+import com.marklogic.mgmt.api.forest.Forest;
+import com.marklogic.mgmt.resource.forests.ForestManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,6 +63,36 @@ public class CommandContext {
 			contextMap.put(COMBINED_CMA_REQUEST_KEY, new Configurations(configuration));
 		} else {
 			configs.addConfig(configuration);
+		}
+	}
+
+	/**
+	 * Added to greatly speed up performance when getting details about all the existing primary forests for each
+	 * database referenced by a plan. In the event that anything fails, the map won't be added to the context
+	 * and any code expecting to use the map will have to fall back to using /manage/v2.
+	 *
+	 * @since 4.5.3
+	 */
+	public Map<String, List<Forest>> getMapOfPrimaryForests() {
+		if (!appConfig.getCmaConfig().isDeployForests()) {
+			return null;
+		}
+		final String key = "ml-app-deployer-mapOfPrimaryForests";
+		if (contextMap.containsKey(key)) {
+			return (Map<String, List<Forest>>) contextMap.get(key);
+		}
+		Logger logger = LoggerFactory.getLogger(getClass());
+		try {
+			logger.info("Retrieving all forest details via CMA");
+			long start = System.currentTimeMillis();
+			Map<String, List<Forest>> mapOfPrimaryForests = new ForestManager(manageClient).getMapOfPrimaryForests();
+			logger.info("Finished retrieving all forests details via CMA; duration: " + (System.currentTimeMillis() - start));
+			contextMap.put(key, mapOfPrimaryForests);
+			return mapOfPrimaryForests;
+		} catch (Exception ex) {
+			logger.warn("Unable to retrieve all forest details, cause: " + ex.getMessage() + "; will fall back to " +
+				"using /manage/v2 when needed for getting details for a forest.");
+			return null;
 		}
 	}
 

--- a/src/main/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/forests/ConfigureForestReplicasCommand.java
@@ -185,22 +185,40 @@ public class ConfigureForestReplicasCommand extends AbstractUndoableCommand {
 		ResourceMapper resourceMapper = new DefaultResourceMapper(api);
 
 		List<Forest> forestsNeedingReplicas = new ArrayList<>();
+		Map<String, List<Forest>> mapOfPrimaryForests = context.getMapOfPrimaryForests();
 
-		for (String forestName : dbMgr.getForestNames(databaseName)) {
-			logger.info(format("Checking the status of forest %s to determine if it is a primary forest and whether or not it has replicas already.", forestName));
-			ForestStatus status = forestManager.getForestStatus(forestName);
-			if (!status.isPrimary()) {
-				logger.info(format("Forest %s is not a primary forest, so not configuring replica forests", forestName));
-				continue;
-			}
-			if (status.hasReplicas()) {
-				logger.info(format("Forest %s already has replicas, so not configuring replica forests", forestName));
-				continue;
-			}
+		/**
+		 * In both blocks below, a forest is not included if it already has replicas. This logic dates back to 2015,
+		 * and is likely due to uncertainty over the various scenarios that can occur if a forest does already have
+		 * replicas. At least as of August 2023, MarkLogic recommends a single replica per forest. Given that no users
+		 * have asked for this check to not be performed and based on MarkLogic's recommendation, it seems reasonable
+		 * to leave this check in for now. However, some ad hoc testing has indicated that this check is unnecessary
+		 * and that it appears to safe to vary the number of replicas per forest. So it likely would be beneficial to
+		 * remove this check at some point.
+		 */
+		if (mapOfPrimaryForests != null && mapOfPrimaryForests.containsKey(databaseName)) {
+			mapOfPrimaryForests.get(databaseName).forEach(forest -> {
+				if (forest.getForestReplica() == null || forest.getForestReplica().size() == 0) {
+					forestsNeedingReplicas.add(forest);
+				}
+			});
+		} else {
+			for (String forestName : dbMgr.getForestNames(databaseName)) {
+				logger.info(format("Checking the status of forest %s to determine if it is a primary forest and whether or not it has replicas already.", forestName));
+				ForestStatus status = forestManager.getForestStatus(forestName);
+				if (!status.isPrimary()) {
+					logger.info(format("Forest %s is not a primary forest, so not configuring replica forests", forestName));
+					continue;
+				}
+				if (status.hasReplicas()) {
+					logger.info(format("Forest %s already has replicas, so not configuring replica forests", forestName));
+					continue;
+				}
 
-			String forestJson = forestManager.getPropertiesAsJson(forestName);
-			Forest forest = resourceMapper.readResource(forestJson, Forest.class);
-			forestsNeedingReplicas.add(forest);
+				String forestJson = forestManager.getPropertiesAsJson(forestName);
+				Forest forest = resourceMapper.readResource(forestJson, Forest.class);
+				forestsNeedingReplicas.add(forest);
+			}
 		}
 
 		return forestsNeedingReplicas;

--- a/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
@@ -132,11 +132,9 @@ public class DeployForestsCommand extends AbstractCommand {
 
 		// As of 4.5.3, if CMA is enabled, then the context should contain a map of all the forests for each database
 		// being deployed. If it's not there, then /manage/v2 will be used instead.
-		if (context.getAppConfig().getCmaConfig().isDeployForests()) {
-			Map<String, List<Forest>> map = (Map<String, List<Forest>>) context.getContextMap().get("ml-app-deployer-forestMap");
-			if (map != null && map.containsKey(this.databaseName)) {
-				existingPrimaryForests = map.get(this.databaseName);
-			}
+		Map<String, List<Forest>> mapOfPrimaryForests = context.getMapOfPrimaryForests();
+		if (mapOfPrimaryForests != null && mapOfPrimaryForests.containsKey(this.databaseName)) {
+			existingPrimaryForests = mapOfPrimaryForests.get(this.databaseName);
 		}
 
 		if (existingPrimaryForests == null) {

--- a/src/main/java/com/marklogic/mgmt/resource/forests/ForestManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/forests/ForestManager.java
@@ -28,7 +28,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -61,14 +60,13 @@ public class ForestManager extends AbstractResourceManager {
 	}
 
 	/**
-	 * Uses CMA to get back all forests in the cluster. Then returns a map where keys are the given database names,
+	 * Uses CMA to get back all forests in the cluster. Then returns a map where keys are the database names,
 	 * and each key has a list of primary forests for that database.
 	 *
-	 * @param databaseNames
 	 * @return
 	 * @since 4.5.3
 	 */
-	public Map<String, List<Forest>> getPrimaryForestsForDatabases(String... databaseNames) {
+	public Map<String, List<Forest>> getMapOfPrimaryForests() {
 		String uri = UriComponentsBuilder.fromUri(getManageClient().buildUri("/manage/v3"))
 			.queryParam("format", "json").queryParam("resource-type", "forest")
 			.encode().toUriString();
@@ -78,23 +76,20 @@ public class ForestManager extends AbstractResourceManager {
 		ArrayNode allPrimaryForests = (ArrayNode) json.get("config").get(0).get("forest");
 		ResourceMapper mapper = new DefaultResourceMapper(new API(getManageClient()));
 
-		List<String> dbNames = Arrays.asList(databaseNames);
-		Map<String, List<Forest>> forestMap = new HashMap<>();
+		Map<String, List<Forest>> mapOfPrimaryForests = new HashMap<>();
 		allPrimaryForests.iterator().forEachRemaining(forest -> {
 			if (forest.has("database")) {
 				String db = forest.get("database").asText();
-				if (dbNames.contains(db)) {
-					List<Forest> forests = forestMap.get(db);
-					if (forests == null) {
-						forests = new ArrayList<>();
-						forestMap.put(db, forests);
-					}
-					forests.add(mapper.readResource(forest.toString(), Forest.class));
+				List<Forest> forests = mapOfPrimaryForests.get(db);
+				if (forests == null) {
+					forests = new ArrayList<>();
+					mapOfPrimaryForests.put(db, forests);
 				}
+				forests.add(mapper.readResource(forest.toString(), Forest.class));
 			}
 		});
-		
-		return forestMap;
+
+		return mapOfPrimaryForests;
 	}
 
 	public void createJsonForestWithName(String name, String host) {

--- a/src/test/java/com/marklogic/mgmt/resource/forests/GetMapOfPrimaryForestsTest.java
+++ b/src/test/java/com/marklogic/mgmt/resource/forests/GetMapOfPrimaryForestsTest.java
@@ -8,10 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GetPrimaryForestsTest extends AbstractMgmtTest {
+public class GetMapOfPrimaryForestsTest extends AbstractMgmtTest {
 
 	/**
 	 * Simple test for verifying this method works for a couple OOTB databases. It is expected that the app-deployer
@@ -20,14 +19,12 @@ public class GetPrimaryForestsTest extends AbstractMgmtTest {
 	 */
 	@Test
 	void test() {
-		Map<String, List<Forest>> forestMap = new ForestManager(manageClient)
-			.getPrimaryForestsForDatabases("App-Services", "Documents");
+		Map<String, List<Forest>> mapOfPrimaryForests = new ForestManager(manageClient).getMapOfPrimaryForests();
 
-		Set<String> dbNames = forestMap.keySet();
+		Set<String> dbNames = mapOfPrimaryForests.keySet();
 		assertTrue(dbNames.contains("App-Services"));
 		assertTrue(dbNames.contains("Documents"));
-		assertEquals(2, dbNames.size());
-		assertTrue(forestMap.get("App-Services").size() > 0);
-		assertTrue(forestMap.get("Documents").size() > 0);
+		assertTrue(mapOfPrimaryForests.get("App-Services").size() > 0);
+		assertTrue(mapOfPrimaryForests.get("Documents").size() > 0);
 	}
 }


### PR DESCRIPTION
Refactored the call for getting a map of forests - moved it into CommandContext so it's easier to reuse by separate commands. 