### PR TITLE
DEVEXP-565 Using map of forests to determining if forests have replicas

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/databases/DeployOtherDatabasesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/databases/DeployOtherDatabasesCommand.java
@@ -34,22 +34,13 @@ import com.marklogic.mgmt.api.forest.Forest;
 import com.marklogic.mgmt.mapper.DefaultResourceMapper;
 import com.marklogic.mgmt.mapper.ResourceMapper;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
-import com.marklogic.mgmt.resource.forests.ForestManager;
 import com.marklogic.mgmt.util.ObjectMapperFactory;
 import com.marklogic.rest.util.JsonNodeUtil;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.*;
 
 /**
  * As of release 3.14.0, this now handles all databases, not just "databases other than the default content database".
@@ -170,7 +161,7 @@ public class DeployOtherDatabasesCommand extends AbstractUndoableCommand {
 	/**
 	 * If no database files are found, may still need to delete the content database in case no file exists for it.
 	 * That's because the command for creating a REST API server will not delete the content database by default.
-	 * <p>
+	 *
 	 * Per ticket #404, this will now do a check to see if the default content database filename is ignored. If so,
 	 * and there are no database files found, then the content database will not be deleted.
 	 *
@@ -401,8 +392,6 @@ public class DeployOtherDatabasesCommand extends AbstractUndoableCommand {
 	 * @param databasePlans
 	 */
 	protected void deployDatabasesAndForestsViaCma(CommandContext context, List<DatabasePlan> databasePlans) {
-		addForestMapToCommandContext(context, databasePlans);
-
 		Configuration dbConfig = new Configuration();
 		// Forests must be included in a separate configuration object
 		Configuration forestConfig = new Configuration();
@@ -424,28 +413,6 @@ public class DeployOtherDatabasesCommand extends AbstractUndoableCommand {
 		databasePlans.forEach(plan -> {
 			plan.getDeployDatabaseCommand().deploySubDatabases(plan.getDatabaseName(), context);
 		});
-	}
-
-	/**
-	 * Added to greatly speed up performance when getting details about all the existing primary forests for each
-	 * database referenced by a plan. In the event that anything fails, the map won't be added to the command context
-	 * and any code expecting to use the map will just have to fall back to use /manage/v2.
-	 *
-	 * @param context
-	 * @param databasePlans
-	 */
-	private void addForestMapToCommandContext(CommandContext context, List<DatabasePlan> databasePlans) {
-		try {
-			Set<String> dbNames = databasePlans.stream().map(plan -> plan.getDatabaseName()).collect(Collectors.toSet());
-			logger.info("Retrieving all forest details via CMA");
-			long start = System.currentTimeMillis();
-			Map<String, List<Forest>> forestMap = new ForestManager(context.getManageClient()).getPrimaryForestsForDatabases(dbNames.toArray(new String[]{}));
-			logger.info("Finished retrieving all forests details via CMA; duration: " + (System.currentTimeMillis() - start));
-			context.getContextMap().put("ml-app-deployer-forestMap", forestMap);
-		} catch (Exception ex) {
-			logger.warn("Unable to retrieve all forest details, cause: " + ex.getMessage() + "; will fall back to " +
-				"using /manage/v2 when needed for getting details for a forest.");
-		}
 	}
 
 	/**

--- a/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/forests/DeployForestsCommand.java
@@ -132,11 +132,9 @@ public class DeployForestsCommand extends AbstractCommand {
 
 		// As of 4.5.3, if CMA is enabled, then the context should contain a map of all the forests for each database
 		// being deployed. If it's not there, then /manage/v2 will be used instead.
-		if (context.getAppConfig().getCmaConfig().isDeployForests()) {
-			Map<String, List<Forest>> map = (Map<String, List<Forest>>) context.getContextMap().get("ml-app-deployer-forestMap");
-			if (map != null && map.containsKey(this.databaseName)) {
-				existingPrimaryForests = map.get(this.databaseName);
-			}
+		Map<String, List<Forest>> mapOfPrimaryForests = context.getMapOfPrimaryForests();
+		if (mapOfPrimaryForests != null && mapOfPrimaryForests.containsKey(this.databaseName)) {
+			existingPrimaryForests = mapOfPrimaryForests.get(this.databaseName);
 		}
 
 		if (existingPrimaryForests == null) {

--- a/src/test/java/com/marklogic/mgmt/resource/forests/GetMapOfPrimaryForestsTest.java
+++ b/src/test/java/com/marklogic/mgmt/resource/forests/GetMapOfPrimaryForestsTest.java
@@ -8,10 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GetPrimaryForestsTest extends AbstractMgmtTest {
+public class GetMapOfPrimaryForestsTest extends AbstractMgmtTest {
 
 	/**
 	 * Simple test for verifying this method works for a couple OOTB databases. It is expected that the app-deployer
@@ -20,14 +19,12 @@ public class GetPrimaryForestsTest extends AbstractMgmtTest {
 	 */
 	@Test
 	void test() {
-		Map<String, List<Forest>> forestMap = new ForestManager(manageClient)
-			.getPrimaryForestsForDatabases("App-Services", "Documents");
+		Map<String, List<Forest>> mapOfPrimaryForests = new ForestManager(manageClient).getMapOfPrimaryForests();
 
-		Set<String> dbNames = forestMap.keySet();
+		Set<String> dbNames = mapOfPrimaryForests.keySet();
 		assertTrue(dbNames.contains("App-Services"));
 		assertTrue(dbNames.contains("Documents"));
-		assertEquals(2, dbNames.size());
-		assertTrue(forestMap.get("App-Services").size() > 0);
-		assertTrue(forestMap.get("Documents").size() > 0);
+		assertTrue(mapOfPrimaryForests.get("App-Services").size() > 0);
+		assertTrue(mapOfPrimaryForests.get("Documents").size() > 0);
 	}
 }


### PR DESCRIPTION
Refactored the call for getting a map of forests - moved it into CommandContext so it's easier to reuse by separate commands. 

Had to redo this PR, merged it too early - I reset dev back to where it was before the previous PR was merged. 