### PR TITLE
Fixing how TDE validation is disabled

### DIFF
--- a/src/test/java/com/marklogic/appdeployer/command/schemas/LoadSchemasTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/schemas/LoadSchemasTest.java
@@ -39,7 +39,7 @@ public class LoadSchemasTest extends AbstractAppDeployerTest {
 
 	@AfterEach
 	public void cleanup() {
-		undeploySampleApp();
+//		undeploySampleApp();
 	}
 
 	@Test
@@ -153,6 +153,9 @@ public class LoadSchemasTest extends AbstractAppDeployerTest {
 		File projectDir = new File("src/test/resources/schemas-project");
 
 		initializeAppConfig(projectDir);
+
+		// Turn off TDE validation, just to verify that the QBV still gets processed
+		appConfig.setTdeValidationEnabled(false);
 		appConfig.getSchemaPaths().add(new File(projectDir, "src/main/more-schemas").getAbsolutePath());
 
 		initializeAppDeployer(new DeployOtherDatabasesCommand(1), new LoadSchemasCommand());
@@ -162,9 +165,15 @@ public class LoadSchemasTest extends AbstractAppDeployerTest {
 		GenericDocumentManager docMgr = client.newDocumentManager();
 		assertNotNull(docMgr.exists("/tde/template1.json"));
 		assertNotNull(docMgr.exists("/tde/template2.json"));
+		assertNotNull(docMgr.exists("/qbv/example.sjs.xml"),
+			"The QBV XML should have been generated, even though TDE validation is disabled.");
 
-		assertTrue(docMgr.readMetadata("/tde/template1.json", new DocumentMetadataHandle()).getCollections().contains("http://marklogic.com/xdmp/tde"));
-		assertTrue(docMgr.readMetadata("/tde/template2.json", new DocumentMetadataHandle()).getCollections().contains("http://marklogic.com/xdmp/tde"));
+		assertTrue(docMgr.readMetadata("/tde/template1.json",
+			new DocumentMetadataHandle()).getCollections().contains("http://marklogic.com/xdmp/tde"));
+		assertTrue(docMgr.readMetadata("/tde/template2.json",
+			new DocumentMetadataHandle()).getCollections().contains("http://marklogic.com/xdmp/tde"));
+		assertTrue(docMgr.readMetadata("/qbv/example.sjs.xml",
+			new DocumentMetadataHandle()).getCollections().contains("http://marklogic.com/xdmp/qbv"));
 	}
 
 	/**

--- a/src/test/resources/schemas-project/src/main/more-schemas/qbv/example.sjs
+++ b/src/test/resources/schemas-project/src/main/more-schemas/qbv/example.sjs
@@ -1,0 +1,3 @@
+'use strict';
+const op = require('/MarkLogic/optic');
+op.fromView('Example2', 'default').generateView('qbv', 'example')


### PR DESCRIPTION
Now that DefaultSchemasLoader can generate QBVs, it always needs a content DatabaseClient. So DefaultSchemasLoader now has an explicit boolean to control whether TDE templates are validated. 