### PR TITLE
DEVEXP-589 Fixing bug with simple SSL for Manage and Admin servers

### DIFF
--- a/src/main/java/com/marklogic/rest/util/RestConfig.java
+++ b/src/main/java/com/marklogic/rest/util/RestConfig.java
@@ -17,6 +17,7 @@ package com.marklogic.rest.util;
 
 import com.marklogic.client.DatabaseClientBuilder;
 import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.ext.modulesloader.ssl.SimpleX509TrustManager;
 import com.marklogic.client.ext.ssl.SslConfig;
 import com.marklogic.client.ext.ssl.SslUtil;
@@ -114,7 +115,8 @@ public class RestConfig {
 					.withSSLContext(StringUtils.hasText(sslProtocol) ?
 						SimpleX509TrustManager.newSSLContext(sslProtocol) :
 						SimpleX509TrustManager.newSSLContext())
-					.withTrustManager(new SimpleX509TrustManager());
+					.withTrustManager(new SimpleX509TrustManager())
+					.withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
 			} else {
 				builder.withSSLProtocol(sslProtocol);
 			}

--- a/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
@@ -16,6 +16,7 @@
 package com.marklogic.mgmt;
 
 import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.mgmt.util.SimplePropertySource;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +103,19 @@ public class DefaultManageConfigFactoryTest  {
 		assertEquals("TLSv1.2", config.getSslProtocol());
 		assertTrue(config.isUseDefaultKeystore());
 		assertEquals("PKIX", config.getTrustManagementAlgorithm());
+	}
+
+	@Test
+	void simpleSsl() {
+		ManageConfig config = configure(
+			"mlManageSimpleSsl", "true",
+			"mlUsername", "admin", 
+			"mlPassword", "admin"
+		);
+
+		DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
+		SSLHostnameVerifier verifier = bean.getSecurityContext().getSSLHostnameVerifier();
+		assertEquals(SSLHostnameVerifier.ANY, verifier, "simpleSsl should default to using the ANY hostname verifier");
 	}
 
 	@Test

--- a/src/test/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactoryTest.java
@@ -15,14 +15,15 @@
  */
 package com.marklogic.mgmt.admin;
 
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.mgmt.util.SimplePropertySource;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
+import com.marklogic.mgmt.util.SimplePropertySource;
 
 public class DefaultAdminConfigFactoryTest  {
 
@@ -75,6 +76,19 @@ public class DefaultAdminConfigFactoryTest  {
 		assertEquals("PKIX", config.getTrustManagementAlgorithm());
 	}
 
+	@Test
+	void simpleSsl() {
+		AdminConfig config = configure(
+			"mlAdminSimpleSsl", "true",
+			"mlUsername", "admin", 
+			"mlPassword", "admin"
+		);
+
+		DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
+		SSLHostnameVerifier verifier = bean.getSecurityContext().getSSLHostnameVerifier();
+		assertEquals(SSLHostnameVerifier.ANY, verifier, "simpleSsl should default to using the ANY hostname verifier");
+	}
+	
 	@Test
 	void cloudApiKeyAndBasePath() {
 		AdminConfig config = configure(


### PR DESCRIPTION
"simpleSsl" now sets the SSL hostname verifier to ANY, mirroring what happens for the Java Client connections as well.