### PR TITLE
MLE-11792 Submitting one request per custom forests file

### DIFF
--- a/src/test/java/com/marklogic/appdeployer/command/forests/DeployCustomForestsTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/forests/DeployCustomForestsTest.java
@@ -51,9 +51,12 @@ public class DeployCustomForestsTest extends AbstractAppDeployerTest {
 		assertTrue(mgr.exists("sample-app-content-custom-3"));
 	}
 
+	/**
+	 * Can examine logging to verify that one request is made per forest.
+	 */
 	@Test
-	public void deployWithCma() {
-		appConfig.getCmaConfig().enableAll();
+	public void deployWithoutCMA() {
+		appConfig.getCmaConfig().setDeployForests(false);
 		test();
 	}
 }


### PR DESCRIPTION
Addresses a support ticket where 900+ forests are in a single file and the request times out. 