### PR TITLE
Added properties for 2-way SSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,20 +19,18 @@ repositories {
 	mavenLocal()
 	mavenCentral()
 	maven {
-		url "https://nexus.marklogic.com/repository/maven-snapshots/"
+		url "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
 	}
 }
 
 dependencies {
-	api 'com.marklogic:ml-javaclient-util:4.6.0'
-	api 'org.springframework:spring-web:5.3.29'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	api 'com.marklogic:ml-javaclient-util:4.7-SNAPSHOT'
+	api 'org.springframework:spring-web:5.3.31'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
 	implementation 'jaxen:jaxen:1.2.0'
 
-	// Forcing usage of 3.4.0 instead of 3.2.0 to address vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002
-	implementation 'com.squareup.okio:okio:3.4.0'
-	implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 	implementation 'io.github.rburgst:okhttp-digest:2.7'
 
 	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
@@ -42,10 +40,10 @@ dependencies {
 	implementation 'commons-codec:commons-codec:1.15'
 
 	// For EqualsBuilder; added in 3.8.1 to support detecting if a mimetype's properties have changed or not
-	implementation "org.apache.commons:commons-lang3:3.12.0"
+	implementation "org.apache.commons:commons-lang3:3.14.0"
 
 	// For PreviewInterceptor; can be excluded if that feature is not used
-	implementation("com.flipkart.zjsonpatch:zjsonpatch:0.4.14") {
+	implementation("com.flipkart.zjsonpatch:zjsonpatch:0.4.16") {
 		// Prefer the api version declared above
 		exclude module: "jackson-databind"
 	}
@@ -57,15 +55,15 @@ dependencies {
 
 	// Don't want to include this in the published jar, just the executable jar
 	compileOnly "com.beust:jcommander:1.82"
-	compileOnly "ch.qos.logback:logback-classic:1.3.5"
+	compileOnly "ch.qos.logback:logback-classic:1.3.14"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
-	testImplementation 'org.springframework:spring-test:5.3.29'
-	testImplementation 'commons-io:commons-io:2.11.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+	testImplementation 'org.springframework:spring-test:5.3.31'
+	testImplementation 'commons-io:commons-io:2.15.1'
 	testImplementation 'xmlunit:xmlunit:1.6'
 
 	// Forcing Spring to use logback for testing instead of commons-logging
-	testImplementation "ch.qos.logback:logback-classic:1.3.5"
+	testImplementation "ch.qos.logback:logback-classic:1.3.14"
 	testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
 	testImplementation "org.slf4j:slf4j-api:1.7.36"
 }
@@ -74,14 +72,14 @@ dependencies {
 sourceSets.main.resources.srcDir 'src/main/java'
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-  classifier 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.main.allSource
 	// For unknown reasons, Gradle 7.1 (but not 6.x) is complaining that AbstractManager.java is a duplicate.
 	duplicatesStrategy = "exclude"
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier "javadoc"
+	archiveClassifier = "javadoc"
 	from javadoc
 }
 javadoc.failOnError = false
@@ -131,9 +129,9 @@ publishing {
 					}
 				}
 				scm {
-					url = "git@github.com:marklogic-community/${project.name}.git"
-					connection = "scm:git@github.com:marklogic-community/${project.name}.git"
-					developerConnection = "scm:git@github.com:marklogic-community/${project.name}.git"
+					url = "git@github.com:marklogic/${project.name}.git"
+					connection = "scm:git@github.com:marklogic/${project.name}.git"
+					developerConnection = "scm:git@github.com:marklogic/${project.name}.git"
 				}
 			}
 			from components.java

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/src/main/java/com/marklogic/appdeployer/AppConfig.java
+++ b/src/main/java/com/marklogic/appdeployer/AppConfig.java
@@ -121,6 +121,16 @@ public class AppConfig {
 	private String restTrustManagementAlgorithm;
 	private String restBasePath;
 
+	// Added in 4.7.0
+	private String restKeyStorePath;
+	private String restKeyStorePassword;
+	private String restKeyStoreType;
+	private String restKeyStoreAlgorithm;
+	private String restTrustStorePath;
+	private String restTrustStorePassword;
+	private String restTrustStoreType;
+	private String restTrustStoreAlgorithm;
+
 	private Integer restPort = DEFAULT_PORT;
 	private Integer testRestPort;
 	private String testRestBasePath;
@@ -142,6 +152,16 @@ public class AppConfig {
 	private String appServicesSslProtocol;
 	private String appServicesTrustManagementAlgorithm;
 	private String appServicesBasePath;
+
+	// Added in 4.7.0
+	private String appServicesKeyStorePath;
+	private String appServicesKeyStorePassword;
+	private String appServicesKeyStoreType;
+	private String appServicesKeyStoreAlgorithm;
+	private String appServicesTrustStorePath;
+	private String appServicesTrustStorePassword;
+	private String appServicesTrustStoreType;
+	private String appServicesTrustStoreAlgorithm;
 
 	// These can all be set to override the default names that are generated off of the "name" attribute.
 	private String groupName = DEFAULT_GROUP;
@@ -416,6 +436,15 @@ public class AppConfig {
 		config.setCloudApiKey(cloudApiKey);
 		config.setBasePath(restBasePath);
 
+		config.setKeyStorePath(restKeyStorePath);
+		config.setKeyStorePassword(restKeyStorePassword);
+		config.setKeyStoreType(restKeyStoreType);
+		config.setKeyStoreAlgorithm(restKeyStoreAlgorithm);
+		config.setTrustStorePath(restTrustStorePath);
+		config.setTrustStorePassword(restTrustStorePassword);
+		config.setTrustStoreType(restTrustStoreType);
+		config.setTrustStoreAlgorithm(restTrustStoreAlgorithm);
+
 		if (restUseDefaultKeystore) {
 		    config.setSslProtocol(StringUtils.hasText(restSslProtocol) ? restSslProtocol : SslUtil.DEFAULT_SSL_PROTOCOL);
 		    config.setTrustManagementAlgorithm(restTrustManagementAlgorithm);
@@ -458,6 +487,15 @@ public class AppConfig {
 		config.setSecurityContextType(appServicesSecurityContextType);
 		config.setCloudApiKey(cloudApiKey);
 		config.setBasePath(appServicesBasePath);
+
+		config.setKeyStorePath(appServicesKeyStorePath);
+		config.setKeyStorePassword(appServicesKeyStorePassword);
+		config.setKeyStoreType(appServicesKeyStoreType);
+		config.setKeyStoreAlgorithm(appServicesKeyStoreAlgorithm);
+		config.setTrustStorePath(appServicesTrustStorePath);
+		config.setTrustStorePassword(appServicesTrustStorePassword);
+		config.setTrustStoreType(appServicesTrustStoreType);
+		config.setTrustStoreAlgorithm(appServicesTrustStoreAlgorithm);
 
 		if (appServicesUseDefaultKeystore) {
 		    config.setSslProtocol(StringUtils.hasText(appServicesSslProtocol) ? appServicesSslProtocol : SslUtil.DEFAULT_SSL_PROTOCOL);
@@ -1555,5 +1593,293 @@ public class AppConfig {
 
 	public void setCascadePermissions(boolean cascadePermissions) {
 		this.cascadePermissions = cascadePermissions;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestKeyStorePath() {
+		return restKeyStorePath;
+	}
+
+	/**
+	 *
+	 * @param restKeyStorePath
+	 * @since 4.7.0
+	 */
+	public void setRestKeyStorePath(String restKeyStorePath) {
+		this.restKeyStorePath = restKeyStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestKeyStorePassword() {
+		return restKeyStorePassword;
+	}
+
+	/**
+	 *
+	 * @param restKeyStorePassword
+	 * @since 4.7.0
+	 */
+	public void setRestKeyStorePassword(String restKeyStorePassword) {
+		this.restKeyStorePassword = restKeyStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestKeyStoreType() {
+		return restKeyStoreType;
+	}
+
+	/**
+	 *
+	 * @param restKeyStoreType
+	 * @since 4.7.0
+	 */
+	public void setRestKeyStoreType(String restKeyStoreType) {
+		this.restKeyStoreType = restKeyStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestKeyStoreAlgorithm() {
+		return restKeyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param restKeyStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setRestKeyStoreAlgorithm(String restKeyStoreAlgorithm) {
+		this.restKeyStoreAlgorithm = restKeyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestTrustStorePath() {
+		return restTrustStorePath;
+	}
+
+	/**
+	 *
+	 * @param restTrustStorePath
+	 * @since 4.7.0
+	 */
+	public void setRestTrustStorePath(String restTrustStorePath) {
+		this.restTrustStorePath = restTrustStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestTrustStorePassword() {
+		return restTrustStorePassword;
+	}
+
+	/**
+	 *
+	 * @param restTrustStorePassword
+	 * @since 4.7.0
+	 */
+	public void setRestTrustStorePassword(String restTrustStorePassword) {
+		this.restTrustStorePassword = restTrustStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestTrustStoreType() {
+		return restTrustStoreType;
+	}
+
+	/**
+	 *
+	 * @param restTrustStoreType
+	 * @since 4.7.0
+	 */
+	public void setRestTrustStoreType(String restTrustStoreType) {
+		this.restTrustStoreType = restTrustStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getRestTrustStoreAlgorithm() {
+		return restTrustStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param restTrustStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setRestTrustStoreAlgorithm(String restTrustStoreAlgorithm) {
+		this.restTrustStoreAlgorithm = restTrustStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesKeyStorePath() {
+		return appServicesKeyStorePath;
+	}
+
+	/**
+	 *
+	 * @param appServicesKeyStorePath
+	 * @since 4.7.0
+	 */
+	public void setAppServicesKeyStorePath(String appServicesKeyStorePath) {
+		this.appServicesKeyStorePath = appServicesKeyStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesKeyStorePassword() {
+		return appServicesKeyStorePassword;
+	}
+
+	/**
+	 *
+	 * @param appServicesKeyStorePassword
+	 * @since 4.7.0
+	 */
+	public void setAppServicesKeyStorePassword(String appServicesKeyStorePassword) {
+		this.appServicesKeyStorePassword = appServicesKeyStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesKeyStoreType() {
+		return appServicesKeyStoreType;
+	}
+
+	/**
+	 *
+	 * @param appServicesKeyStoreType
+	 * @since 4.7.0
+	 */
+	public void setAppServicesKeyStoreType(String appServicesKeyStoreType) {
+		this.appServicesKeyStoreType = appServicesKeyStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesKeyStoreAlgorithm() {
+		return appServicesKeyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param appServicesKeyStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setAppServicesKeyStoreAlgorithm(String appServicesKeyStoreAlgorithm) {
+		this.appServicesKeyStoreAlgorithm = appServicesKeyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesTrustStorePath() {
+		return appServicesTrustStorePath;
+	}
+
+	/**
+	 *
+	 * @param appServicesTrustStorePath
+	 * @since 4.7.0
+	 */
+	public void setAppServicesTrustStorePath(String appServicesTrustStorePath) {
+		this.appServicesTrustStorePath = appServicesTrustStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesTrustStorePassword() {
+		return appServicesTrustStorePassword;
+	}
+
+	/**
+	 *
+	 * @param appServicesTrustStorePassword
+	 * @since 4.7.0
+	 */
+	public void setAppServicesTrustStorePassword(String appServicesTrustStorePassword) {
+		this.appServicesTrustStorePassword = appServicesTrustStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesTrustStoreType() {
+		return appServicesTrustStoreType;
+	}
+
+	/**
+	 *
+	 * @param appServicesTrustStoreType
+	 * @since 4.7.0
+	 */
+	public void setAppServicesTrustStoreType(String appServicesTrustStoreType) {
+		this.appServicesTrustStoreType = appServicesTrustStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getAppServicesTrustStoreAlgorithm() {
+		return appServicesTrustStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param appServicesTrustStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setAppServicesTrustStoreAlgorithm(String appServicesTrustStoreAlgorithm) {
+		this.appServicesTrustStoreAlgorithm = appServicesTrustStoreAlgorithm;
 	}
 }

--- a/src/main/java/com/marklogic/appdeployer/DefaultAppConfigFactory.java
+++ b/src/main/java/com/marklogic/appdeployer/DefaultAppConfigFactory.java
@@ -206,6 +206,45 @@ public class DefaultAppConfigFactory extends PropertySourceFactory implements Ap
 			config.setCloudApiKey(prop);
 		});
 
+		propertyConsumerMap.put("mlKeyStorePath", (config, prop) -> {
+			logger.info("REST and App-Services key store path: " + prop);
+			config.setRestKeyStorePath(prop);
+			config.setAppServicesKeyStorePath(prop);
+		});
+		propertyConsumerMap.put("mlKeyStorePassword", (config, prop) -> {
+			config.setRestKeyStorePassword(prop);
+			config.setAppServicesKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreType", (config, prop) -> {
+			logger.info("REST and App-Services key store type: " + prop);
+			config.setRestKeyStoreType(prop);
+			config.setAppServicesKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("REST and App-Services key store algorithm: " + prop);
+			config.setRestKeyStoreAlgorithm(prop);
+			config.setAppServicesKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlTrustStorePath", (config, prop) -> {
+			logger.info("REST and App-Services trust store path: " + prop);
+			config.setRestTrustStorePath(prop);
+			config.setAppServicesTrustStorePath(prop);
+		});
+		propertyConsumerMap.put("mlTrustStorePassword", (config, prop) -> {
+			config.setRestTrustStorePassword(prop);
+			config.setAppServicesTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreType", (config, prop) -> {
+			logger.info("REST and App-Services trust store type: " + prop);
+			config.setRestTrustStoreType(prop);
+			config.setAppServicesTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("REST and App-Services trust store algorithm: " + prop);
+			config.setRestTrustStoreAlgorithm(prop);
+			config.setAppServicesTrustStoreAlgorithm(prop);
+		});
+
 		/**
 		 * Defaults to port 8000. In rare cases, the ML App-Services app server will have been changed to listen on a
 		 * different port, in which case you can set this to that port.
@@ -291,6 +330,37 @@ public class DefaultAppConfigFactory extends PropertySourceFactory implements Ap
 			String appServicesPath = StringUtils.hasText(cloudBasePath) ? cloudBasePath + prop : prop;
 			logger.info("App-Services base path: " + appServicesPath);
 			config.setAppServicesBasePath(appServicesPath);
+		});
+
+		propertyConsumerMap.put("mlAppServicesKeyStorePath", (config, prop) -> {
+			logger.info("App-Services key store path: " + prop);
+			config.setAppServicesKeyStorePath(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesKeyStorePassword", (config, prop) -> {
+			config.setAppServicesKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesKeyStoreType", (config, prop) -> {
+			logger.info("App-Services key store type: " + prop);
+			config.setAppServicesKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("App-Services key store algorithm: " + prop);
+			config.setAppServicesKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesTrustStorePath", (config, prop) -> {
+			logger.info("App-Services trust store path: " + prop);
+			config.setAppServicesTrustStorePath(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesTrustStorePassword", (config, prop) -> {
+			config.setAppServicesTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesTrustStoreType", (config, prop) -> {
+			logger.info("App-Services trust store type: " + prop);
+			config.setAppServicesTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlAppServicesTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("App-Services trust store algorithm: " + prop);
+			config.setAppServicesTrustStoreAlgorithm(prop);
 		});
 
 		/**
@@ -419,6 +489,37 @@ public class DefaultAppConfigFactory extends PropertySourceFactory implements Ap
 		propertyConsumerMap.put("mlRestTrustManagementAlgorithm", (config, prop) -> {
 			logger.info("Using trust management algorithm for SSL for client REST API server: " + prop);
 			config.setRestTrustManagementAlgorithm(prop);
+		});
+
+		propertyConsumerMap.put("mlRestKeyStorePath", (config, prop) -> {
+			logger.info("REST key store path: " + prop);
+			config.setRestKeyStorePath(prop);
+		});
+		propertyConsumerMap.put("mlRestKeyStorePassword", (config, prop) -> {
+			config.setRestKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlRestKeyStoreType", (config, prop) -> {
+			logger.info("REST key store type: " + prop);
+			config.setRestKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlRestKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("REST key store algorithm: " + prop);
+			config.setRestKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlRestTrustStorePath", (config, prop) -> {
+			logger.info("REST trust store path: " + prop);
+			config.setRestTrustStorePath(prop);
+		});
+		propertyConsumerMap.put("mlRestTrustStorePassword", (config, prop) -> {
+			config.setRestTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlRestTrustStoreType", (config, prop) -> {
+			logger.info("REST trust store type: " + prop);
+			config.setRestTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlRestTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("REST trust store algorithm: " + prop);
+			config.setRestTrustStoreAlgorithm(prop);
 		});
 
 

--- a/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
+++ b/src/main/java/com/marklogic/mgmt/DefaultManageConfigFactory.java
@@ -127,19 +127,16 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 			config.setBasePath(managePath);
 		});
 
-	    propertyConsumerMap.put("mlManageScheme", (config, prop) -> {
-		    logger.info("Manage scheme: " + prop);
-		    config.setScheme(prop);
-	    });
-
 	    propertyConsumerMap.put("mlManageSimpleSsl", (config, prop) -> {
 		    logger.info("Use simple SSL for Manage app server: " + prop);
 		    config.setConfigureSimpleSsl(Boolean.parseBoolean(prop));
+			config.setScheme("https");
 	    });
 
 	    propertyConsumerMap.put("mlManageSslProtocol", (config, prop) -> {
 		    logger.info("Using SSL protocol for Manage app server: " + prop);
 		    config.setSslProtocol(prop);
+			config.setScheme("https");
 	    });
 
 		propertyConsumerMap.put("mlManageSslHostnameVerifier", (config, prop) -> {
@@ -156,12 +153,79 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 	    propertyConsumerMap.put("mlManageUseDefaultKeystore", (config, prop) -> {
 	    	logger.info("Using default JVM keystore for SSL for Manage app server: " + prop);
 	    	config.setUseDefaultKeystore(Boolean.parseBoolean(prop));
+			config.setScheme("https");
 	    });
 
 	    propertyConsumerMap.put("mlManageTrustManagementAlgorithm", (config, prop) -> {
 		    logger.info("Using trust management algorithm for SSL for Manage app server: " + prop);
 		    config.setTrustManagementAlgorithm(prop);
 	    });
+
+		propertyConsumerMap.put("mlKeyStorePath", (config, prop) -> {
+			logger.info("Manage key store path: " + prop);
+			config.setKeyStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlKeyStorePassword", (config, prop) -> {
+			config.setKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreType", (config, prop) -> {
+			logger.info("Manage key store type: " + prop);
+			config.setKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("Manage key store algorithm: " + prop);
+			config.setKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlTrustStorePath", (config, prop) -> {
+			logger.info("Manage trust store path: " + prop);
+			config.setTrustStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlTrustStorePassword", (config, prop) -> {
+			config.setTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreType", (config, prop) -> {
+			logger.info("Manage trust store type: " + prop);
+			config.setTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("Manage trust store algorithm: " + prop);
+			config.setTrustStoreAlgorithm(prop);
+		});
+
+		propertyConsumerMap.put("mlManageKeyStorePath", (config, prop) -> {
+			logger.info("Manage key store path: " + prop);
+			config.setKeyStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlManageKeyStorePassword", (config, prop) -> {
+			config.setKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlManageKeyStoreType", (config, prop) -> {
+			logger.info("Manage key store type: " + prop);
+			config.setKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlManageKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("Manage key store algorithm: " + prop);
+			config.setKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlManageTrustStorePath", (config, prop) -> {
+			logger.info("Manage trust store path: " + prop);
+			config.setTrustStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlManageTrustStorePassword", (config, prop) -> {
+			config.setTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlManageTrustStoreType", (config, prop) -> {
+			logger.info("Manage trust store type: " + prop);
+			config.setTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlManageTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("Manage trust store algorithm: " + prop);
+			config.setTrustStoreAlgorithm(prop);
+		});
 
 	    propertyConsumerMap.put("mlManageCleanJsonPayloads", (config, prop) -> {
 		    logger.info("Cleaning Management API JSON payloads: " + prop);
@@ -186,6 +250,11 @@ public class DefaultManageConfigFactory extends PropertySourceFactory implements
 	    propertyConsumerMap.put("mlSecurityPassword", (config, prop) -> {
 		    config.setSecurityPassword(prop);
 	    });
+
+		propertyConsumerMap.put("mlManageScheme", (config, prop) -> {
+			logger.info("Manage scheme: " + prop);
+			config.setScheme(prop);
+		});
 
 		// Processed last so that it can override scheme/port
 		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {

--- a/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
+++ b/src/main/java/com/marklogic/mgmt/admin/DefaultAdminConfigFactory.java
@@ -124,19 +124,16 @@ public class DefaultAdminConfigFactory extends PropertySourceFactory implements 
 			config.setBasePath(adminPath);
 		});
 
-		propertyConsumerMap.put("mlAdminScheme", (config, prop) -> {
-		    logger.info("Admin interface scheme: " + prop);
-		    config.setScheme(prop);
-	    });
-
 	    propertyConsumerMap.put("mlAdminSimpleSsl", (config, prop) -> {
 		    logger.info("Use simple SSL for Admin interface: " + prop);
 		    config.setConfigureSimpleSsl(Boolean.parseBoolean(prop));
+			config.setScheme("https");
 	    });
 
 	    propertyConsumerMap.put("mlAdminSslProtocol", (config, prop) -> {
 		    logger.info("Using SSL protocol for Admin app server: " + prop);
 		    config.setSslProtocol(prop);
+			config.setScheme("https");
 	    });
 
 		propertyConsumerMap.put("mlAdminSslHostnameVerifier", (config, prop) -> {
@@ -153,12 +150,84 @@ public class DefaultAdminConfigFactory extends PropertySourceFactory implements 
 	    propertyConsumerMap.put("mlAdminUseDefaultKeystore", (config, prop) -> {
 		    logger.info("Using default JVM keystore for SSL for Admin app server: " + prop);
 		    config.setUseDefaultKeystore(Boolean.parseBoolean(prop));
+			config.setScheme("https");
 	    });
 
 	    propertyConsumerMap.put("mlAdminTrustManagementAlgorithm", (config, prop) -> {
 		    logger.info("Using trust management algorithm for SSL for Admin app server: " + prop);
 		    config.setTrustManagementAlgorithm(prop);
 	    });
+
+		propertyConsumerMap.put("mlKeyStorePath", (config, prop) -> {
+			logger.info("Admin key store path: " + prop);
+			config.setKeyStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlKeyStorePassword", (config, prop) -> {
+			config.setKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreType", (config, prop) -> {
+			logger.info("Admin key store type: " + prop);
+			config.setKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("Admin key store algorithm: " + prop);
+			config.setKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlTrustStorePath", (config, prop) -> {
+			logger.info("Admin trust store path: " + prop);
+			config.setTrustStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlTrustStorePassword", (config, prop) -> {
+			config.setTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreType", (config, prop) -> {
+			logger.info("Admin trust store type: " + prop);
+			config.setTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("Admin trust store algorithm: " + prop);
+			config.setTrustStoreAlgorithm(prop);
+		});
+
+		propertyConsumerMap.put("mlAdminKeyStorePath", (config, prop) -> {
+			logger.info("Admin key store path: " + prop);
+			config.setKeyStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlAdminKeyStorePassword", (config, prop) -> {
+			config.setKeyStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlAdminKeyStoreType", (config, prop) -> {
+			logger.info("Admin key store type: " + prop);
+			config.setKeyStoreType(prop);
+		});
+		propertyConsumerMap.put("mlAdminKeyStoreAlgorithm", (config, prop) -> {
+			logger.info("Admin key store algorithm: " + prop);
+			config.setKeyStoreAlgorithm(prop);
+		});
+		propertyConsumerMap.put("mlAdminTrustStorePath", (config, prop) -> {
+			logger.info("Admin trust store path: " + prop);
+			config.setTrustStorePath(prop);
+			config.setScheme("https");
+		});
+		propertyConsumerMap.put("mlAdminTrustStorePassword", (config, prop) -> {
+			config.setTrustStorePassword(prop);
+		});
+		propertyConsumerMap.put("mlAdminTrustStoreType", (config, prop) -> {
+			logger.info("Admin trust store type: " + prop);
+			config.setTrustStoreType(prop);
+		});
+		propertyConsumerMap.put("mlAdminTrustStoreAlgorithm", (config, prop) -> {
+			logger.info("Admin trust store algorithm: " + prop);
+			config.setTrustStoreAlgorithm(prop);
+		});
+
+		propertyConsumerMap.put("mlAdminScheme", (config, prop) -> {
+			logger.info("Admin scheme: " + prop);
+			config.setScheme(prop);
+		});
 
 		// Processed last so that it can override scheme/port
 		propertyConsumerMap.put("mlCloudApiKey", (config, prop) -> {

--- a/src/main/java/com/marklogic/rest/util/RestConfig.java
+++ b/src/main/java/com/marklogic/rest/util/RestConfig.java
@@ -54,6 +54,16 @@ public class RestConfig {
 	@Deprecated
 	private X509HostnameVerifier hostnameVerifier;
 
+	// Added in 4.7.0 for 2-way SSL.
+	private String keyStorePath;
+	private String keyStorePassword;
+	private String keyStoreType;
+	private String keyStoreAlgorithm;
+	private String trustStorePath;
+	private String trustStorePassword;
+	private String trustStoreType;
+	private String trustStoreAlgorithm;
+
 	public RestConfig() {
 	}
 
@@ -73,6 +83,12 @@ public class RestConfig {
 		this.cloudApiKey = other.cloudApiKey;
 		this.basePath = other.basePath;
 
+		this.authType = other.authType;
+		this.certFile = other.certFile;
+		this.certPassword = other.certPassword;
+		this.externalName = other.externalName;
+		this.samlToken = other.samlToken;
+
 		this.configureSimpleSsl = other.configureSimpleSsl;
 		this.useDefaultKeystore = other.useDefaultKeystore;
 		this.sslProtocol = other.sslProtocol;
@@ -80,6 +96,15 @@ public class RestConfig {
 		this.sslContext = other.sslContext;
 		this.hostnameVerifier = other.hostnameVerifier;
 		this.sslHostnameVerifier = other.sslHostnameVerifier;
+
+		this.keyStorePath = other.keyStorePath;
+		this.keyStorePassword = other.keyStorePassword;
+		this.keyStoreAlgorithm = other.keyStoreAlgorithm;
+		this.keyStoreType = other.keyStoreType;
+		this.trustStorePath = other.trustStorePath;
+		this.trustStorePassword = other.trustStorePassword;
+		this.trustStoreType = other.trustStoreType;
+		this.trustStoreAlgorithm = other.trustStoreAlgorithm;
 	}
 
 	public DatabaseClientBuilder newDatabaseClientBuilder() {
@@ -95,7 +120,18 @@ public class RestConfig {
 			.withCertificatePassword(getCertPassword())
 			.withKerberosPrincipal(getExternalName())
 			.withSAMLToken(getSamlToken())
-			.withSSLHostnameVerifier(getSslHostnameVerifier());
+			.withSSLHostnameVerifier(getSslHostnameVerifier())
+			// These 8 were added in 4.7.0. They do not conflict with the SSL config below; if the user is setting
+			// these, they won't have a reason to provide their own SSLContext nor request that the default keystore
+			// be used or simple SSL be used.
+			.withKeyStorePath(getKeyStorePath())
+			.withKeyStorePassword(getKeyStorePassword())
+			.withKeyStoreType(getKeyStoreType())
+			.withKeyStoreAlgorithm(getKeyStoreAlgorithm())
+			.withTrustStorePath(getTrustStorePath())
+			.withTrustStorePassword(getTrustStorePassword())
+			.withTrustStoreType(getTrustStoreType())
+			.withTrustStoreAlgorithm(getTrustStoreAlgorithm());
 
 		if (getSslContext() != null) {
 			builder.withSSLContext(getSslContext());
@@ -313,5 +349,133 @@ public class RestConfig {
 
 	public void setSamlToken(String samlToken) {
 		this.samlToken = samlToken;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStorePath() {
+		return keyStorePath;
+	}
+
+	/**
+	 * @param keyStorePath
+	 * @since 4.7.0
+	 */
+	public void setKeyStorePath(String keyStorePath) {
+		this.keyStorePath = keyStorePath;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStorePassword() {
+		return keyStorePassword;
+	}
+
+	/**
+	 * @param keyStorePassword
+	 * @since 4.7.0
+	 */
+	public void setKeyStorePassword(String keyStorePassword) {
+		this.keyStorePassword = keyStorePassword;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStoreType() {
+		return keyStoreType;
+	}
+
+	/**
+	 * @param keyStoreType
+	 * @since 4.7.0
+	 */
+	public void setKeyStoreType(String keyStoreType) {
+		this.keyStoreType = keyStoreType;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStoreAlgorithm() {
+		return keyStoreAlgorithm;
+	}
+
+	/**
+	 * @param keyStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setKeyStoreAlgorithm(String keyStoreAlgorithm) {
+		this.keyStoreAlgorithm = keyStoreAlgorithm;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStorePath() {
+		return trustStorePath;
+	}
+
+	/**
+	 * @param trustStorePath
+	 * @since 4.7.0
+	 */
+	public void setTrustStorePath(String trustStorePath) {
+		this.trustStorePath = trustStorePath;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStorePassword() {
+		return trustStorePassword;
+	}
+
+	/**
+	 * @param trustStorePassword
+	 * @since 4.7.0
+	 */
+	public void setTrustStorePassword(String trustStorePassword) {
+		this.trustStorePassword = trustStorePassword;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStoreType() {
+		return trustStoreType;
+	}
+
+	/**
+	 * @param trustStoreType
+	 * @since 4.7.0
+	 */
+	public void setTrustStoreType(String trustStoreType) {
+		this.trustStoreType = trustStoreType;
+	}
+
+	/**
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStoreAlgorithm() {
+		return trustStoreAlgorithm;
+	}
+
+	/**
+	 * @param trustStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setTrustStoreAlgorithm(String trustStoreAlgorithm) {
+		this.trustStoreAlgorithm = trustStoreAlgorithm;
 	}
 }

--- a/src/test/java/com/marklogic/appdeployer/DefaultAppConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/appdeployer/DefaultAppConfigFactoryTest.java
@@ -851,6 +851,84 @@ public class DefaultAppConfigFactoryTest {
 		assertEquals("/my/domain/my/test/server", config.getTestRestBasePath());
 	}
 
+	@Test
+	void keyStore() {
+		AppConfig config = configure(
+			"mlRestKeyStorePath", "/rest.jks",
+			"mlRestKeyStorePassword", "abc",
+			"mlRestKeyStoreType", "JKS",
+			"mlRestKeyStoreAlgorithm", "SunX509",
+			"mlAppServicesKeyStorePath", "/apps.jks",
+			"mlAppServicesKeyStorePassword", "123",
+			"mlAppServicesKeyStoreType", "JKS2",
+			"mlAppServicesKeyStoreAlgorithm", "SunX5092"
+		);
+
+		assertEquals("/rest.jks", config.getRestKeyStorePath());
+		assertEquals("abc", config.getRestKeyStorePassword());
+		assertEquals("JKS", config.getRestKeyStoreType());
+		assertEquals("SunX509", config.getRestKeyStoreAlgorithm());
+		assertEquals("/apps.jks", config.getAppServicesKeyStorePath());
+		assertEquals("123", config.getAppServicesKeyStorePassword());
+		assertEquals("JKS2", config.getAppServicesKeyStoreType());
+		assertEquals("SunX5092", config.getAppServicesKeyStoreAlgorithm());
+	}
+
+	@Test
+	void trustStore() {
+		AppConfig config = configure(
+			"mlRestTrustStorePath", "/rest.jks",
+			"mlRestTrustStorePassword", "abc",
+			"mlRestTrustStoreType", "JKS",
+			"mlRestTrustStoreAlgorithm", "SunX509",
+			"mlAppServicesTrustStorePath", "/apps.jks",
+			"mlAppServicesTrustStorePassword", "123",
+			"mlAppServicesTrustStoreType", "JKS2",
+			"mlAppServicesTrustStoreAlgorithm", "SunX5092"
+		);
+
+		assertEquals("/rest.jks", config.getRestTrustStorePath());
+		assertEquals("abc", config.getRestTrustStorePassword());
+		assertEquals("JKS", config.getRestTrustStoreType());
+		assertEquals("SunX509", config.getRestTrustStoreAlgorithm());
+		assertEquals("/apps.jks", config.getAppServicesTrustStorePath());
+		assertEquals("123", config.getAppServicesTrustStorePassword());
+		assertEquals("JKS2", config.getAppServicesTrustStoreType());
+		assertEquals("SunX5092", config.getAppServicesTrustStoreAlgorithm());
+	}
+
+	@Test
+	void globalKeyStoreAndTrustStore() {
+		AppConfig config = configure(
+			"mlKeyStorePath", "/key.jks",
+			"mlKeyStorePassword", "abc",
+			"mlKeyStoreType", "JKS1",
+			"mlKeyStoreAlgorithm", "SunX5091",
+			"mlTrustStorePath", "/trust.jks",
+			"mlTrustStorePassword", "123",
+			"mlTrustStoreType", "JKS2",
+			"mlTrustStoreAlgorithm", "SunX5092"
+		);
+
+		assertEquals("/key.jks", config.getRestKeyStorePath());
+		assertEquals("abc", config.getRestKeyStorePassword());
+		assertEquals("JKS1", config.getRestKeyStoreType());
+		assertEquals("SunX5091", config.getRestKeyStoreAlgorithm());
+		assertEquals("/key.jks", config.getAppServicesKeyStorePath());
+		assertEquals("abc", config.getAppServicesKeyStorePassword());
+		assertEquals("JKS1", config.getAppServicesKeyStoreType());
+		assertEquals("SunX5091", config.getAppServicesKeyStoreAlgorithm());
+
+		assertEquals("/trust.jks", config.getRestTrustStorePath());
+		assertEquals("123", config.getRestTrustStorePassword());
+		assertEquals("JKS2", config.getRestTrustStoreType());
+		assertEquals("SunX5092", config.getRestTrustStoreAlgorithm());
+		assertEquals("/trust.jks", config.getAppServicesTrustStorePath());
+		assertEquals("123", config.getAppServicesTrustStorePassword());
+		assertEquals("JKS2", config.getAppServicesTrustStoreType());
+		assertEquals("SunX5092", config.getAppServicesTrustStoreAlgorithm());
+	}
+
 	private AppConfig configure(String... properties) {
 		return new DefaultAppConfigFactory(new SimplePropertySource(properties)).newAppConfig();
 	}

--- a/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
+++ b/src/test/java/com/marklogic/mgmt/DefaultManageConfigFactoryTest.java
@@ -99,6 +99,7 @@ public class DefaultManageConfigFactoryTest  {
 			"mlManageTrustManagementAlgorithm", "PKIX"
 		);
 
+		assertEquals("https", config.getScheme());
 		assertTrue(config.isConfigureSimpleSsl());
 		assertEquals("TLSv1.2", config.getSslProtocol());
 		assertTrue(config.isUseDefaultKeystore());
@@ -109,9 +110,11 @@ public class DefaultManageConfigFactoryTest  {
 	void simpleSsl() {
 		ManageConfig config = configure(
 			"mlManageSimpleSsl", "true",
-			"mlUsername", "admin", 
+			"mlUsername", "admin",
 			"mlPassword", "admin"
 		);
+
+		assertEquals("https", config.getScheme());
 
 		DatabaseClientFactory.Bean bean = config.newDatabaseClientBuilder().buildBean();
 		SSLHostnameVerifier verifier = bean.getSecurityContext().getSSLHostnameVerifier();
@@ -266,6 +269,62 @@ public class DefaultManageConfigFactoryTest  {
 			"If a user specifies both mlCloudBasePath and mlManageBasePath, then the assumption is that they've " +
 				"changed the default Manage base path but it still begins with the common base path defined by " +
 				"mlCloudBasePath.");
+	}
+
+	@Test
+	void keyStore() {
+		ManageConfig config = configure(
+			"mlManageKeyStorePath", "/my.jks",
+			"mlManageKeyStorePassword", "abc123",
+			"mlManageKeyStoreType", "JKS",
+			"mlManageKeyStoreAlgorithm", "SunX509"
+		);
+
+		assertEquals("/my.jks", config.getKeyStorePath());
+		assertEquals("abc123", config.getKeyStorePassword());
+		assertEquals("JKS", config.getKeyStoreType());
+		assertEquals("SunX509", config.getKeyStoreAlgorithm());
+		assertEquals("https", config.getScheme());
+	}
+
+	@Test
+	void trustStore() {
+		ManageConfig config = configure(
+			"mlManageTrustStorePath", "/my.jks",
+			"mlManageTrustStorePassword", "abc123",
+			"mlManageTrustStoreType", "JKS",
+			"mlManageTrustStoreAlgorithm", "SunX509"
+		);
+
+		assertEquals("/my.jks", config.getTrustStorePath());
+		assertEquals("abc123", config.getTrustStorePassword());
+		assertEquals("JKS", config.getTrustStoreType());
+		assertEquals("SunX509", config.getTrustStoreAlgorithm());
+		assertEquals("https", config.getScheme());
+	}
+
+	@Test
+	void globalKeyStoreAndTrustStore() {
+		ManageConfig config = configure(
+			"mlKeyStorePath", "/key.jks",
+			"mlKeyStorePassword", "abc",
+			"mlKeyStoreType", "JKS1",
+			"mlKeyStoreAlgorithm", "SunX5091",
+			"mlTrustStorePath", "/trust.jks",
+			"mlTrustStorePassword", "123",
+			"mlTrustStoreType", "JKS2",
+			"mlTrustStoreAlgorithm", "SunX5092"
+		);
+
+		assertEquals("/key.jks", config.getKeyStorePath());
+		assertEquals("abc", config.getKeyStorePassword());
+		assertEquals("JKS1", config.getKeyStoreType());
+		assertEquals("SunX5091", config.getKeyStoreAlgorithm());
+		assertEquals("/trust.jks", config.getTrustStorePath());
+		assertEquals("123", config.getTrustStorePassword());
+		assertEquals("JKS2", config.getTrustStoreType());
+		assertEquals("SunX5092", config.getTrustStoreAlgorithm());
+		assertEquals("https", config.getScheme());
 	}
 
 	private ManageConfig configure(String... properties) {


### PR DESCRIPTION
Added 8 properties for 4 connections - rest, appServices, manage, and admin - and then 8 more "global" properties that affect all 4 connections. 

The tests ensure that the properties are applied the config objects correctly, and the Java Client project has tests to verify that the properties work. Manual testing will be done with ml-gradle to ensure that everything works together. 